### PR TITLE
Convert script to installable Python package

### DIFF
--- a/oads_download.py
+++ b/oads_download.py
@@ -1791,7 +1791,8 @@ def main(
         logger.info(f"Files downloaded: {download_counter} ({size_msg} at ~{mean_download_speed:.2f} MB/s)")
         logger.info(f"Files unzipped:   {unzip_counter}")
 
-if __name__ == "__main__":
+def main_cli():
+    """Entry point for the command-line tool."""
     args = get_parsed_arguments()
 
     remove_old_logs(max_num_logs=MAX_NUM_LOGS, max_age_logs=MAX_AGE_LOGS)
@@ -1802,3 +1803,6 @@ if __name__ == "__main__":
     except Exception as e:
         logger.exception(e)
         raise
+
+if __name__ == "__main__":
+    main_cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oads-download"
+dynamic = ["version"]
+authors = [{ name = "Leonard König", email = "koenig@tropos.de" }]
+description = "A Python script to search and download EarthCARE data"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache License, Version 2.0" }
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "requests",
+    "numpy",
+    "pandas",
+    "beautifulsoup4",
+    "lxml",
+    "tomli;python_version<'3.11'",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/koenigleon/oads-download"
+"Bug Tracker" = "https://github.com/koenigleon/oads-download/issues"
+
+[project.scripts]
+oads-download = "oads_download:main_cli"
+
+[tool.setuptools]
+py-modules = ["oads_download"]
+
+[tool.setuptools.dynamic]
+version = { attr = "oads_download.__version__" }


### PR DESCRIPTION
With the suggested changes it would be possible to simply install the download script as a package with
```
pip install git+https://github.com/koenigleon/oads-download
```
and call the script through an entry point with
```
oads-download -h
```

You can also test it already with
```
pip install git+https://github.com/MDornacher/oads-download@python-package
```